### PR TITLE
Add comm_code option AG6 as available for HS classification.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,8 @@ Authors@R: c(person("Chris", "Muir",
                   role = "rev", 
                   comment = c(ORCID = "0000-0002-3092-3493", 
                               "Rafael reviewed the package for rOpenSci, 
-                              see https://github.com/ropensci/onboarding/issues/141")))
+                              see https://github.com/ropensci/onboarding/issues/141")),
+            person("Juergen", "Amann", role=c("ctb")))
 Description: Interface with and extract data from the United Nations Comtrade 
   API <https://comtrade.un.org/data/>. Comtrade provides country level shipping 
   data for a variety of commodities, these functions allow for easy API query 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 comtradr 0.2.2.09000
 ====================
 
+## NEW FEATURES
+
+* Modifications to `ct_search()` to add support for commodity code `ag6` ([#30](https://github.com/ropensci/comtradr/pull/30))
+
 ## BUG FIXES
 
 * Passing an API token string to `ct_register_token()` now properly bumps the hourly rate limit up to 10,000

--- a/R/ct_search.R
+++ b/R/ct_search.R
@@ -548,7 +548,7 @@ is_year_month <- function(x) {
 #'
 #' @noRd
 codes_as_ints <- function(char_vect) {
-  if (any(tolower(char_vect) %in% c("all", "total", "ag1", "ag2", "ag3", "ag4", "ag5"))) {
+  if (any(tolower(char_vect) %in% c("all", "total", "ag1", "ag2", "ag3", "ag4", "ag5", "ag6"))) {
     return(TRUE)
   }
   as_ints <- suppressWarnings(as.integer(char_vect))


### PR DESCRIPTION
Hi,

Option `comm_code` should ideally also recognise aggregation level `AG6` of the HS classification. Please see example below.

Thanks a lot.

-------------------

Example using updated `ct_search()`:
```
> ct_search(reporters       = "Spain",
+           freq            = "monthly",
+           start_date      = "2020-01", 
+           end_date        = "2020-01",
+           partners        = "China",
+           trade_direction = "exports",
+           commod_codes    = "AG6") %>% 
+   as_tibble() %>%
+   select(classification, period, aggregate_level, trade_flow, reporter, partner, 
+          commodity_code, trade_value_usd, netweight_kg) %>%
+   slice(1:2)
# A tibble: 2 x 9
  classification period aggregate_level trade_flow reporter partner commodity_code trade_value_usd netweight_kg
  <chr>           <int>           <int> <chr>      <chr>    <chr>   <chr>                    <int>        <int>
1 HS             202001               6 Exports    Spain    China   020630                  149985       124614
2 HS             202001               6 Exports    Spain    China   050690                   17720        19104
```



Data query using [comtrade.un.org](https://comtrade.un.org/data/): 
![image](https://user-images.githubusercontent.com/16940930/100551788-42ef0f80-3283-11eb-9f08-da209a23c53e.png)



