### PR TITLE
Token validation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@ comtradr 0.2.2.09000
 
 ## BUG FIXES
 
+* Function `ct_register_token()` now checks if the provided token is recognized by the official API and only grants "premium" credentials if it is ([#34](https://github.com/ropensci/comtradr/issues/34)).
+
 * Passing an API token string to `ct_register_token()` now properly bumps the hourly rate limit up to 10,000
 ([#21](https://github.com/ropensci/comtradr/issues/21)).
 

--- a/R/rate_limit.R
+++ b/R/rate_limit.R
@@ -69,6 +69,24 @@ reset_hourly_limits <- function() {
 }
 
 
+#' Validate Token
+#'
+#' Verifies validity of token provided by user.
+#'
+#' @param token char string, API token
+#'
+#' @return Returns token if successfully validated by API; NULL otherwise.
+#'
+#' @noRd
+validate_token <- function (token) {
+  result <- NULL
+  tryCatch(result <- jsonlite::fromJSON(
+    paste0("https://comtrade.un.org/api/getUserInfo?token=", token)),
+    error = function(e) e)
+  if (!is.null(result)) token else result
+}
+
+
 #' Comtradr set API token
 #'
 #' Function to set an API token for the UN Comtrade API. Details on tokens and
@@ -86,6 +104,9 @@ reset_hourly_limits <- function() {
 ct_register_token <- function(token) {
   # input validation.
   stopifnot(is.character(token) || is.null(token))
+
+  # Verify validity of token
+  token <- validate_token(token)
 
   # Get number of queries left for the current hour.
   queries_this_hour <- get("queries_this_hour", envir = ct_env)

--- a/tests/testthat/test-ct_register_token.R
+++ b/tests/testthat/test-ct_register_token.R
@@ -3,14 +3,14 @@ context("ct_register_token")
 test_that("setting API token ajusts options", {
   skip_on_cran()
 
-  # Set API token.
+  # Check API token.
   ct_register_token("some_token_str")
 
   ct_options <- getOption("comtradr")$comtrade
 
-  expect_equal(ct_options$token, "some_token_str")
-  expect_equal(ct_options$account_type, "premium")
-  expect_equal(ct_options$per_hour_limit, 10000)
+  expect_equal(ct_options$token, NULL)
+  expect_equal(ct_options$account_type, "standard")
+  expect_equal(ct_options$per_hour_limit, 100)
 
   # Reset all API credentials back to the pkg load defaults.
   ct_register_token(NULL)


### PR DESCRIPTION
Function `ct_register_token()` now checks if the provided token is recognized by the official API and only grants "premium" credentials if it is ([#34](https://github.com/ropensci/comtradr/issues/34)).